### PR TITLE
Fix plugin name typo

### DIFF
--- a/src/main/resources/META-INF/plugin.xml
+++ b/src/main/resources/META-INF/plugin.xml
@@ -36,7 +36,7 @@
 <hasAdoc>true</hasAdoc>
 
 <detailedDescription>Chef is an open-source, systems integration framework built specifically for automating the cloud, making it easy to deploy servers and scale applications throughout your entire infrastructure.
-The EC-Cher plugin interacts with the Chef shell through the Chef commander agent, allowing you to perform several key functions, such as:
+The EC-Chef plugin interacts with the Chef shell through the Chef commander agent, allowing you to perform several key functions, such as:
 
 * Download Cookbooks from the Chef repository to the local node.
 * Install Cookbooks on local nodes (with Git).


### PR DESCRIPTION
Note: this spelling mistake shows up (after going through the machine) in https://docs.cloudbees.com/plugins/cd/ec-chef